### PR TITLE
Feat/add ma50 200 800 psylevels open prices

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Tends to work well on virtually all timeframes, but personally prefer to use it 
 _Using the "plus" version is optional, if you only want the buy/sell signals - use the "base" version._
 
 [![Chart Snapshot](https://tradingview.com/x/4fzGlOqI)](https://tradingview.com/x/4fzGlOqI)
-_With all the "+" indicators turned on, it may look a little confusing at first glance - but if you switch them on/off you should be able to quickly work out what each one is / means._
+_With all the "+" indicators turned on, it may look a little confusing at first glance - but if you switch them on/off you should be able to quickly work out what each one is / means, as well as work out your preferences._
 
 ## What are vector candles?
 Vector Candles (inspired to add from TradersReality/MT4) are candles that are color coded to indicate higher volumes, and likely flip points / direction changes, or confirmations.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ Tends to work well on virtually all timeframes, but personally prefer to use it 
 # [SBST Plus](https://github.com/Triex/TriexDev-SuperBuySellTrend-TradingView-Trend-Indicator/tree/master/sbst-plus) 
 _Using the "plus" version is optional, if you only want the buy/sell signals - use the "base" version._
 
+[![Chart Snapshot](https://tradingview.com/x/4fzGlOqI)](https://tradingview.com/x/4fzGlOqI)
+_With all the "+" indicators turned on, it may look a little confusing at first glance - but if you switch them on/off you should be able to quickly work out what each one is / means._
+
 ## What are vector candles?
 Vector Candles (inspired to add from TradersReality/MT4) are candles that are color coded to indicate higher volumes, and likely flip points / direction changes, or confirmations.
 
@@ -126,6 +129,7 @@ Psychological & daily levels help to confirm, or find pivot points.
 
 I personally switch these off sometimes to reduce the amount of lines on the chart, but can be very useful.
 
+---
 ---
 
 ## Dev Notes & Future Ideas

--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ Buy volume is above 0 (positive), sell volume is below 0 (-negative) on the char
 
 It will show the Buy + Sell volume for each candle on the timeframe you are viewing.
 
+## MA 50, 200, 800
+Moving Averages help to work out the current trend / direction. (eg, often; above 200 = bullish, below 200 = bearish). I tend to watch the 50+200 day MA's as primary trendlines for general use.
+
+## Psy Levels, Daily Hi/Lo & opens
+Psychological & daily levels help to confirm, or find pivot points. 
+
+I personally switch these off sometimes to reduce the amount of lines on the chart, but can be very useful.
+
 ---
 
 ## Dev Notes & Future Ideas

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Buy volume is above 0 (positive), sell volume is below 0 (-negative) on the char
 It will show the Buy + Sell volume for each candle on the timeframe you are viewing.
 
 ## MA 50, 200, 800
-Moving Averages help to work out the current trend / direction. (eg, often; above 200 = bullish, below 200 = bearish). I tend to watch the 50+200 day MA's as primary trendlines for general use.
+Moving Averages help to work out the current trend / direction. (eg, often; above 200 = bullish, below 200 = bearish). I tend to watch the 50+200 day MA locations and crossovers as primary trendlines for general use. 
 
 ## Psy Levels, Daily Hi/Lo & opens
 Psychological & daily levels help to confirm, or find pivot points. 

--- a/sbst-plus/README.md
+++ b/sbst-plus/README.md
@@ -57,7 +57,7 @@ Buy volume is above 0 (positive), sell volume is below 0 (-negative) on the char
 It will show the Buy + Sell volume for each candle on the timeframe you are viewing.
 
 ## MA 50, 200, 800
-Moving Averages help to work out the current trend / direction. (eg, often; above 200 = bullish, below 200 = bearish). I tend to watch the 50+200 day MA's as primary trendlines for general use.
+Moving Averages help to work out the current trend / direction. (eg, often; above 200 = bullish, below 200 = bearish). I tend to watch the 50+200 day MA locations and crossovers as primary trendlines for general use. 
 
 ## Psy Levels, Daily Hi/Lo & opens
 Psychological & daily levels help to confirm, or find pivot points. 

--- a/sbst-plus/README.md
+++ b/sbst-plus/README.md
@@ -13,6 +13,9 @@ Have been using this for myself, so thought it would be nice to share publicly. 
 # [SBST Plus](https://github.com/Triex/TriexDev-SuperBuySellTrend-TradingView-Trend-Indicator/tree/master/sbst-plus) 
 _Using the "plus" version is optional, if you only want the buy/sell signals - use the "base" version._
 
+[![Chart Snapshot](https://tradingview.com/x/4fzGlOqI)](https://tradingview.com/x/4fzGlOqI)
+_With all the "+" indicators turned on, it may look a little confusing at first glance - but if you switch them on/off you should be able to quickly work out what each one is / means._
+
 ## What are vector candles?
 Vector Candles (inspired to add from TradersReality/MT4) are candles that are color coded to indicate higher volumes, and likely flip points / direction changes, or confirmations.
 
@@ -64,6 +67,7 @@ Psychological & daily levels help to confirm, or find pivot points.
 
 I personally switch these off sometimes to reduce the amount of lines on the chart, but can be very useful.
 
+---
 ---
 
 # [Base Indicator](https://github.com/Triex/TriexDev-SuperBuySellTrend-TradingView-Trend-Indicator)
@@ -123,7 +127,8 @@ _You can use this and other indicators to confirm likeliness of a direction chan
 
 Tends to work well on virtually all timeframes, but personally prefer to use it on 5min,15min,1hr, 4hr, daily, weekly. Will still work for shorter/other timeframes, but may be more accurate on mid ones.
 
---- 
+---
+---
 
 ## Dev Notes & Future Ideas
 - [X] Added Bollinger Bands (with on/off toggle - default state is off)

--- a/sbst-plus/README.md
+++ b/sbst-plus/README.md
@@ -14,7 +14,7 @@ Have been using this for myself, so thought it would be nice to share publicly. 
 _Using the "plus" version is optional, if you only want the buy/sell signals - use the "base" version._
 
 [![Chart Snapshot](https://tradingview.com/x/4fzGlOqI)](https://tradingview.com/x/4fzGlOqI)
-_With all the "+" indicators turned on, it may look a little confusing at first glance - but if you switch them on/off you should be able to quickly work out what each one is / means._
+_With all the "+" indicators turned on, it may look a little confusing at first glance - but if you switch them on/off you should be able to quickly work out what each one is / means, as well as work out your preferences._
 
 ## What are vector candles?
 Vector Candles (inspired to add from TradersReality/MT4) are candles that are color coded to indicate higher volumes, and likely flip points / direction changes, or confirmations.

--- a/sbst-plus/README.md
+++ b/sbst-plus/README.md
@@ -56,6 +56,14 @@ Buy volume is above 0 (positive), sell volume is below 0 (-negative) on the char
 
 It will show the Buy + Sell volume for each candle on the timeframe you are viewing.
 
+## MA 50, 200, 800
+Moving Averages help to work out the current trend / direction. (eg, often; above 200 = bullish, below 200 = bearish). I tend to watch the 50+200 day MA's as primary trendlines for general use.
+
+## Psy Levels, Daily Hi/Lo & opens
+Psychological & daily levels help to confirm, or find pivot points. 
+
+I personally switch these off sometimes to reduce the amount of lines on the chart, but can be very useful.
+
 ---
 
 # [Base Indicator](https://github.com/Triex/TriexDev-SuperBuySellTrend-TradingView-Trend-Indicator)

--- a/sbst-plus/TriexDev - SuperBuySellTrend Plus.pine
+++ b/sbst-plus/TriexDev - SuperBuySellTrend Plus.pine
@@ -1,6 +1,6 @@
-
 //@version=5
-indicator('TriexDev - SuperBuySellTrend (PLUS+)', overlay=true, format=format.price, precision=2, timeframe='')
+indicator('TriexDev - SuperBuySellTrend (PLUS+)', overlay=true, format=format.price, precision=2)
+
 // The average true range (ATR) is a technical analysis indicator, which
 // measures market volatility by decomposing the entire range of an 
 // asset price for that period.
@@ -22,6 +22,9 @@ Multiplier2 = input.float(title='ATR Multiplier 2', step=0.1, defval=1.6)
 changeATR = input(title='Change ATR Calculation Method ?', defval=true)
 showsignals = input(title='Show Buy/Sell Signals ?', defval=true)
 highlighting = input(title='Highlighter On/Off ?', defval=true)
+// Toggles
+toggleBBon = input.bool(group='Bollinger Bands', title='Toggle Bollinger Bands', defval=false, inline='bb')
+toggleVolumeOn = input.bool(group='Up/Down Volume Analysis', title='Up/Down Volume Analysis', defval=false, inline='updownvolon')
 // vectorcandleson = input(title='Vector Candles On/Off ? - toggle not working', defval=false)
 atr2 = ta.sma(ta.tr, Periods)
 atr = changeATR ? ta.atr(Periods) : atr2
@@ -80,11 +83,206 @@ alertcondition(sellSignalx, title='SBST Sell Confirm', message='SBST Sell Direct
 changeCondx = trendx != trendx[1]
 alertcondition(changeCondx, title='SBST Direction Confirmation', message='SBST has confirmed direction!')
 
+// Config
+pivot_offset_input = input.int(group='Label offsets', title='Pivot', defval=-5, inline='labeloffset')
+label_offset_input = input.int(group='Label offsets', title='MA/HiLo', defval=5, inline='labeloffset')
 // Vector candles inspired from TradersReality
 // Price, Volume, Support, Resistance Analysis (PVSRA)
 // PVSRA helps determine if the Marker Makers are bearish or bullish, and if their price movement is in the "run for profits"  or "position building" phase.
 bool overridesym = input.bool(group='PVSRA', title='Override chart symbol?', defval=false, inline='pvsra')
 string pvsra_sym = input.symbol(group='PVSRA', title='', defval='INDEX:BTCUSD', tooltip='You can use INDEX:BTCUSD or you can combine multiple feeds, for example \'(BINANCE:BTCUSDT+COINBASE:BTCUSD)\'. Note that adding too many will slow things down.', inline='pvsra')
+// EMA
+showEmas = input.bool(group='EMAs', title='Show EMAs?', defval=true, inline='showemas')
+labelEmas = input.bool(group='EMAs', title='EMA Labels?', defval=false, inline='showemas')
+threeEmaColor = input.color(group='EMAs', title='50', defval=color.rgb(31, 188, 211, 0), inline='emacolors')
+fourEmaColor = input.color(group='EMAs', title='200', defval=color.rgb(255, 255, 255, 0), inline='emacolors')
+fiveEmaColor = input.color(group='EMAs', title='800', defval=color.rgb(50, 34, 144, 0), inline='emacolors')
+EmaCloudColor = input.color(group='EMAs', title='EMA Cloud', defval=color.rgb(155, 47, 174, 60), inline='emacloud')
+EmaCloudBorderColor = input.color(group='EMAs', title='Border', defval=color.rgb(18, 137, 123, 100), inline='emacloud')
+// Pivot Points
+showDayHighLow = input.bool(group='Daily High/low', title='Show Hi/Lo: Daily?', defval=true, inline='highlow')
+showWeekHighLow = input.bool(group='Daily High/low', title='Weekly?', defval=true, inline='highlow')
+showDayHighLowLabels = input.bool(group='Daily High/low', title='Show labels?', defval=true, inline='highlow')
+
+/// market boxes and daily open only on intraday
+bool show = timeframe.isminutes and timeframe.multiplier <= 240 and timeframe.multiplier >= 4
+
+bool show_dly = timeframe.isminutes  //and timeframe.multiplier < 240
+bool show_rectangle9 = input.bool(group='Daily Open', defval=true, title='Show: line ?', inline='dopenconf') and show_dly
+bool show_label9 = input.bool(group='Daily Open', defval=true, title='Label?', inline='dopenconf') and show_rectangle9 and show_dly
+bool showallDly = input.bool(group='Daily Open', defval=false, title='Show historical daily opens?', inline='dopenconf')
+color sess9col = input.color(group='Daily Open', title='Daily Open Color', defval=color.rgb(254, 234, 78, 0), inline='dopenconf1')
+//color sess9colLabel = input(group="Daily Open", title="", type=input.color, defval=color.rgb(254,234,78,0), inline="dopenconf1")
+
+// Psy Levels
+bool showPsy = timeframe.isminutes and (timeframe.multiplier == 60 or timeframe.multiplier == 30 or timeframe.multiplier == 15 or timeframe.multiplier == 5 or timeframe.multiplier == 3 or timeframe.multiplier == 1)   
+bool show_psylevels = input.bool(group='Weekly Psy Levels (valid tf 1h/30min/15min/5min/3min/1min)', defval=true, title='Show: Levels?', inline='psyconf') and showPsy
+bool show_psylabel = input.bool(group='Weekly Psy Levels (valid tf 1h/30min/15min/5min/3min/1min)', defval=true, title='Labels?', inline='psyconf', tooltip="The Psy High/Low will only show on these timeframes: 1h/30min/15min/5min/3min/1min. It is disabled on all others. This is because the calculation requires a candle to start at the correct time for Sydney but in other timeframes the data does not have values at the designated time for the Sydney session.") and show_psylevels
+bool showallPsy = false//input.bool(Weekly Psy Levels (valid tf 1h/30min/15min/5min/3min/1min), defval=false, title='Show historical psy levels?', inline='psyconf')
+color psycolH = input.color(group='Weekly Psy Levels (valid tf 1h/30min/15min/5min/3min/1min)', title='Psy Hi Color', defval=color.new(color.orange, 30), inline='psyconf1')
+color psycolL = input.color(group='Weekly Psy Levels (valid tf 1h/30min/15min/5min/3min/1min)', title='Psy Low Color', defval=color.new(color.orange, 30), inline='psyconf1')
+var string psy_gmt = "GMT+3"
+
+//Non repainting security
+f_security(_symbol, _res, _src, _repaint) =>
+    request.security(_symbol, _res, _src[_repaint ? 0 : barstate.isrealtime ? 1 : 0])[_repaint ? 0 : barstate.isrealtime ? 0 : 1]
+
+// Basic vars (needed in functions)
+
+// Only render intraday
+validTimeFrame = timeframe.isintraday == true
+
+// If above the 5 minute, we start drawing yesterday. below, we start today
+levelsstart = timeframe.isseconds == true or timeframe.isminutes == true and timeframe.multiplier < 5 ? time('D') : time('D') - 86400 * 1000
+levelsstartbar = ta.barssince(levelsstart)
+
+// Functions
+// new_bar: check if we're on a new bar within the session in a given resolution
+new_bar(res) =>
+    ta.change(time(res)) != 0
+
+pivot_label_x_offset = time_close + pivot_offset_input * timeframe.multiplier * 60 * 1000
+label_x_offset = time_close + label_offset_input * timeframe.multiplier * 60 * 1000
+
+//Right_Label
+r_label(ry, rtext, rstyle, rcolor, valid) =>
+    if valid and barstate.isrealtime
+        rLabel = label.new(x=label_x_offset, y=ry, text=rtext, xloc=xloc.bar_time, style=rstyle, textcolor=rcolor, textalign=text.align_right)
+        label.delete(rLabel[1])
+        
+draw_line(x_series, res, tag, xColor, xStyle, xWidth, xExtend, isLabelValid, xLabelOffset) =>
+    var line x_line = na
+
+    if new_bar(res) and validTimeFrame
+        line.set_x2(x_line, bar_index)
+        line.set_extend(x_line, extend.none)
+
+        x_line := line.new(bar_index, x_series, bar_index, x_series, extend=xExtend, color=xColor, style=xStyle, width=xWidth)
+        line.delete(x_line[1])
+
+    if not na(x_line) and line.get_x2(x_line) != bar_index
+        line.set_x2(x_line, bar_index)
+
+    if isLabelValid  //showADRLabels and validTimeFrame
+        x_label = label.new(xLabelOffset, x_series, tag, xloc=xloc.bar_time, style=label.style_none, textcolor=xColor)
+        label.delete(x_label[1])
+
+draw_pivot(pivot_level, res, tag, pivotColor, pivotStyle, pivotWidth, pivotExtend, isLabelValid) =>
+    var line pivot_line = na
+
+    // Start drawing yesterday
+    if new_bar(res) and validTimeFrame
+        line.set_x2(pivot_line, bar_index)
+        line.set_extend(pivot_line, extend.none)
+        pivot_line := line.new(bar_index, pivot_level, bar_index, pivot_level, extend=pivotExtend, color=pivotColor, style=pivotStyle, width=pivotWidth)
+        line.delete(pivot_line[1])
+    if not na(pivot_line) and line.get_x2(pivot_line) != bar_index
+        line.set_x2(pivot_line, bar_index)
+    if isLabelValid  //showADRLabels and validTimeFrame
+        pivot_label = label.new(pivot_label_x_offset, pivot_level, tag, xloc=xloc.bar_time, style=label.style_none, textcolor=pivotColor, textalign=text.align_right)
+
+        label.delete(pivot_label[1])
+    if not barstate.islast
+        line.set_x2(pivot_line, x=bar_index)
+    else
+        line.set_xloc(pivot_line, levelsstart, time_close + 1 * 86400000, xloc=xloc.bar_time)
+    pivot_line
+
+draw_linelabel_gmt_custSession(pivot_level, res, sessionString, tag, pivotColor, pivotStyle, pivotWidth, pivotExtend, isLabelValid, label_offset, sessStartAdjustMilis, gmt_off_val) =>
+    var line pivot_line = na
+
+    gmtD = gmt_off_val
+    current_session = time(res, sessionString, gmtD) - sessStartAdjustMilis
+    if not na(current_session)
+        pivot_line = line.new(current_session, pivot_level, timenow, pivot_level, xloc=xloc.bar_time, extend=pivotExtend, color=pivotColor, style=pivotStyle, width=pivotWidth)
+        line.delete(pivot_line[1])
+    if isLabelValid
+        pivot_label = label.new(label_offset, pivot_level, tag, xloc=xloc.bar_time, style=label.style_none, textcolor=pivotColor, textalign=text.align_right)
+        label.delete(pivot_label[1])
+    pivot_line
+
+//sessions line function
+showOrFunctionX(show_orX, sessX, sessXOrCalc, orX_h, orX_l, sessXcol) =>
+    if show_orX
+        if sessX and sessXOrCalc
+            line.new(bar_index, orX_h, bar_index, orX_l, color=sessXcol, style=line.style_dotted)
+
+    if not sessX and sessX[1]
+        line.new(bar_index - 1, orX_h[1], bar_index - 1, orX_l[1], color=sessXcol, style=line.style_dotted)
+
+//calculate orX_h, orX_l
+calcXOrHL(sessX, sessXorcalc, lookbackOrBars) =>
+    float orX_h = na
+    float orX_l = na
+    orX_h := sessX ? orX_h[1] : na
+    orX_l := sessX ? orX_l[1] : na
+
+    if sessXorcalc
+        for i = 0 to lookbackOrBars by 1
+            orX_h := i == 0 ? high : math.max(high[i], orX_h)
+            orX_l := i == 0 ? low : math.min(low[i], orX_l)
+            orX_l
+    [orX_l, orX_h]
+
+////////////
+//calculate sess and sessorcalc function
+///////////
+// calcSessAndSessOr(sessXTime, showX_or, lookbackMinsX, lookbackOrBarsX) =>
+//     int sessX = time(timeframe.period, sessXTime)
+//     bool sessXorcalc = sessX[lookbackOrBarsX] and na(sessX[lookbackOrBarsX + 1]) and showX_or
+//     [sessX, sessXorcalc]
+
+// EMAs
+threeEmaLength = 50
+fourEmaLength = 200
+fiveEmaLength = 800
+
+threeEma = ta.ema(close, threeEmaLength)
+plot(showEmas ? threeEma : na, color=threeEmaColor, title='50 Ema')
+
+fourEma = ta.ema(close, fourEmaLength)
+plot(showEmas ? fourEma : na, color=fourEmaColor, title='200 Ema')
+
+fiveEma = ta.ema(close, fiveEmaLength)
+plot(showEmas ? fiveEma : na, color=fiveEmaColor, linewidth=2, title='800 Ema')
+
+// Ema 50 cloud placed here for readability on data window
+cloudSizeEMA = ta.stdev(close, threeEmaLength * 2) / 4
+p1EMA = plot(showEmas ? threeEma + cloudSizeEMA : na, 'Upper 50 Ema Cloud', color=EmaCloudBorderColor, offset=0)
+p2EMA = plot(showEmas ? threeEma - cloudSizeEMA : na, 'Lower 50 Ema Cloud', color=EmaCloudBorderColor, offset=0)
+fill(p1EMA, p2EMA, title='EMA 50 Cloud', color=EmaCloudColor, transp=90)
+
+//Label emas
+
+r_label(threeEma, '50 Ema', label.style_none, threeEmaColor, labelEmas)
+r_label(fourEma, '200 Ema', label.style_none, fourEmaColor, labelEmas)
+r_label(fiveEma, '800 Ema', label.style_none, fiveEmaColor, labelEmas) //ry, rtext, rstyle, rcolor,valid
+
+// Get Daily price data
+dayHigh = f_security(syminfo.tickerid, 'D', high, false)
+dayLow = f_security(syminfo.tickerid, 'D', low, false)
+dayOpen = f_security(syminfo.tickerid, 'D', open, false)
+dayClose = f_security(syminfo.tickerid, 'D', close, false)
+
+// Daily H/L 
+weekHigh = f_security(syminfo.tickerid, 'W', high, false)
+weekLow = f_security(syminfo.tickerid, 'W', low, false)
+
+validDHLTimeFrame = timeframe.isintraday == true
+validWHLTimeFrame = timeframe.isintraday == true or timeframe.isdaily == true
+isToday = year(timenow) == year(time) and month(timenow) == month(time) and dayofmonth(timenow) == dayofmonth(time)
+isThisWeek = year(timenow) == year(time) and weekofyear(timenow) == weekofyear(time)
+
+plot(validDHLTimeFrame and showDayHighLow and (showDayHighLow ? true : isToday) ? dayHigh : na, linewidth=1, color=color.new(color.blue, 50), style=plot.style_linebr, title="YDay Hi")
+plot(validDHLTimeFrame and showDayHighLow and (showDayHighLow ? true : isToday) ? dayLow : na, linewidth=1, color=color.new(color.blue, 50), style=plot.style_linebr, title="YDay Lo")
+r_label(dayHigh, 'YDay Hi', label.style_none, color.blue, validDHLTimeFrame and showDayHighLow and showDayHighLowLabels)  //ry, rtext, rstyle, rcolor, valid
+r_label(dayLow, 'YDay Lo', label.style_none, color.blue, validDHLTimeFrame and showDayHighLow and showDayHighLowLabels)
+
+plot(validWHLTimeFrame and showWeekHighLow and (showWeekHighLow ? true : isThisWeek) ? weekHigh : na, linewidth=1, color=color.new(color.green, 60), style=plot.style_linebr, title="LWeek Hi")
+plot(validWHLTimeFrame and showWeekHighLow and (showWeekHighLow ? true : isThisWeek) ? weekLow : na, linewidth=1, color=color.new(color.green, 60), style=plot.style_linebr, title="LWeek Lo")
+
+r_label(weekHigh, 'LWeek Hi', label.style_none, color.green, validWHLTimeFrame and showWeekHighLow and showDayHighLowLabels)  //ry, rtext, rstyle, rcolor, valid
+r_label(weekLow, 'LWeek Lo', label.style_none, color.green, validWHLTimeFrame and showWeekHighLow and showDayHighLowLabels)
 
 // PVSRA
 // From MT4 source:
@@ -113,7 +311,7 @@ pvsra_close = overridesym == true ? pvsra_security_4 : close
 pvsra_security_5 = pvsra_security('', open)
 pvsra_open = overridesym == true ? pvsra_security_5 : open
 
-//label.new(overridesym ? 0 : na, low, text = "PVSRA Override: " + pvsra_sym, xloc = xloc.bar_index, yloc=yloc.belowbar,style=label.style_label_down, size=size.huge)
+r_label(high - (high - low) / 2, 'PVSRA Override Active!', label.style_none, color.orange, overridesym)  //ry, rtext, rstyle, rcolor, valid
 
 // The below math matches MT4 PVSRA indicator source
 // average volume from last 10 candles
@@ -160,8 +358,82 @@ barcolor(candleColor)
 
 alertcondition(va > 0, title='Alert on Vector Candle', message='{{ticker}} Vector Candle on the {{interval}}')
 
+// Daily open 
+daily_open = request.security(syminfo.tickerid, 'D', open, lookahead=barmerge.lookahead_on)
+// Date & time variables
+current_year = year(timenow)
+current_month = month(timenow)
+current_weekofyear = weekofyear(timenow)
+current_dayofmonth = dayofmonth(timenow)
+current_dayofweek = dayofweek(timenow)
+
+// Opens (re-test previous values, so we take the closing price as that is defining the upcoming open price)
+
+bar_is_today = year == current_year and weekofyear == current_weekofyear and dayofweek == current_dayofweek
+plot(show_rectangle9 and bar_is_today and validTimeFrame ? daily_open : na, title='Daily open', color=sess9col, style=plot.style_line, linewidth=1)
+
+// Labels
+if show_label9 and barstate.isrealtime
+    if show_rectangle9
+        r_label(daily_open, 'Daily Open', label.style_none, sess9col, validTimeFrame)
+
+
+//************//
+// Psy Levels //
+//************//
+calc_psy_hilo(gmtoffsetPsy) =>
+
+    //4 hour res based on how mt4 does it
+    //mt4 code
+    //int Li_4 = iBarShift(NULL, PERIOD_H4, iTime(NULL, PERIOD_W1, Li_0)) - 2 - Offset;
+    //ObjectCreate("PsychHi", OBJ_TREND, 0, Time[0], iHigh(NULL, PERIOD_H4, iHighest(NULL, PERIOD_H4, MODE_HIGH, 2, Li_4)), iTime(NULL, PERIOD_W1, 0), iHigh(NULL, PERIOD_H4,
+    //iHighest(NULL, PERIOD_H4, MODE_HIGH, 2, Li_4)));
+
+    //so basically because the session is 8 hours and we are looking at a 4 hour resolution we only need to take the highest high an lowest low of 2 bars
+    //we use the gmt offset to adjust the 0000-0800 session to Sydney open which is at 2100 during dst and at 2000 otherwize. (dst - spring foward, fall back)
+    in_session = time('240', '0000-0800:1', gmtoffsetPsy)
+    new_session = in_session and not in_session[1]
+    float psy_high = 0.0
+    float psy_low = 100000000000.0
+
+    psy_high := new_session ? high : in_session ? math.max(high, psy_high[1]) : psy_high[1]
+    psy_low := new_session ? low : in_session ? math.min(low, psy_low[1]) : psy_low[1]
+    [psy_high, psy_low]
+
+[psy_high, psy_low] = calc_psy_hilo(psy_gmt)
+//isThisWeekPsy = year(timenow, psy_gmt) == year(time, psy_gmt) and weekofyear(timenow, psy_gmt) == weekofyear(time, psy_gmt)
+
+//TODO cannot plot as max plots per script exceeded : removed market sessions plots
+plot(showPsy and show_psylevels and showallPsy ? psy_high : na, color=psycolH, style=plot.style_line, linewidth=1, editable=false, title="Psy-Hi")  //, offset=psy_plot_offset)
+plot(showPsy and show_psylevels and showallPsy ? psy_low : na, color=psycolL, style=plot.style_line, linewidth=1, editable=false, title="Psy-Lo")  //, offset=psy_plot_offset)
+
+//if barstate.isnew
+psy_calc_start = timestamp(psy_gmt, year, month, dayofweek.wednesday, 00, 00, 00)
+psy_calc_end = timestamp(psy_gmt, year, month, dayofweek.wednesday, 08, 00, 00)
+time_now_gmt = time('D', '0000-0800:1', psy_gmt)
+psy_calc_inProgress = not na(time_now_gmt - psy_calc_start >= 0) and not na(time_now_gmt - psy_calc_end <= 0)
+
+stylePsy = line.style_solid
+psy_hi_label = 'Psy-Hi'  //+tostring(gmtoffsetxxx)//tostring((timenow-timestamp(syminfo.timezone,year(time,syminfo.timezone),month(time,syminfo.timezone),dayofmonth(time,syminfo.timezone),hour(time,syminfo.timezone),minute(time,syminfo.timezone),second(time,syminfo.timezone)))/(1000*60*60))+" "+syminfo.timezone//+str.format("{0,date,h a ZZZ}", timestamp(year,month,dayofmonth,hour,minute,second)) + " "+syminfo.timezone
+psy_lo_label = 'Psy-Lo'
+
+if psy_calc_inProgress
+    //stylePsy := line.style_dashed //this does not work for style correctly but it does for the label which is odd
+    psy_hi_label := 'Psy-Hi calculating...'
+    psy_lo_label := 'Psy-Lo calculating...'  //+tostring(psy_calc_inProgress)
+    psy_lo_label
+
+if showallPsy
+    r_label(psy_high, psy_hi_label, label.style_none, psycolH, validTimeFrame and show_psylabel)
+    r_label(psy_low, psy_lo_label, label.style_none, psycolL, validTimeFrame and show_psylabel)
+    showallPsy  //just here to trick if-else into working
+else
+    if show_psylevels
+        draw_linelabel_gmt_custSession(psy_high, 'D', '0000-0800:1', psy_hi_label, psycolH, stylePsy, 1, extend.none, show_psylabel and show_psylevels, label_x_offset, 0, psy_gmt)
+        draw_linelabel_gmt_custSession(psy_low, 'D', '0000-0800:1', psy_lo_label, psycolL, stylePsy, 1, extend.none, show_psylabel and show_psylevels, label_x_offset, 0, psy_gmt)
+    showallPsy  //just here to trick if-else into working
+
 // Bollinger Bands
-toggleBBon = input.bool(group='Bollinger Bands', title='Toggle Bollinger Bands', defval=false, inline='bb')
 lengthBB = input.int(20, minval=1, group="Bollinger Bands")
 srcBB = input(close, title="Source", group="Bollinger Bands")
 multBB = input.float(2.0, minval=0.001, maxval=50, title="StdDev", group="Bollinger Bands")
@@ -176,8 +448,6 @@ p2 = plot(lowerBB, "Lower", color=#2962FF, offset = offsetBB)
 fill(p1, p2, title = "Background", color=color.rgb(33, 150, 243, 95))
 
 // Up/Down Volume Analysis
-toggleVolumeOn = input.bool(group='Up/Down Volume Analysis', title='Up/Down Volume Analysis', defval=false, inline='updownvolon')
-
 lowerTimeframeTooltip = "The indicator scans lower timeframe data to approximate Up/Down volume. By default, the timeframe is chosen automatically. These inputs override this with a custom timeframe.
  \n\nHigher timeframes provide more historical data, but the data will be less precise."
 useCustomTimeframeInput = input.bool(false, "Use custom timeframe", tooltip = lowerTimeframeTooltip)


### PR DESCRIPTION
Changes/Additions general note:

Inspired from TradersReality/MT4 indicators.

**Added 50,200,800 EMA lines [Toggleable On/Off]**
Moving Averages help to work out the current trend / direction. (eg, often; above 200 = bullish, below 200 = bearish) [i]I tend to watch the 50+200 day MA locations and crossovers as primary trendlines for general use.[/i]

**Added Psy Levels, Daily/Weekly Hi-Lo & Daily Open prices [Toggleable On/Off]**
Psychological & daily levels help to confirm, or find pivot points. (I personally sometimes switch off to reduce the amount of lines on the chart, but can be very useful)

**Tidied and rearranged settings**
Made it easier to follow, Bollinger Bands & Volume Analysis are set to disabled by default

[![Chart Snapshot](https://www.tradingview.com/x/4fzGlOqI)](https://www.tradingview.com/x/4fzGlOqI)
With all the indicators turned on, it may look a little confusing at first glance - but if you switch them on and off you should be able to quickly work out what each one is / means.